### PR TITLE
Reorganize tech stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
   <p>
     <img alt="Profile views" src="https://komarev.com/ghpvc/?username=joe-huber&style=for-the-badge&color=8A2BE2" />
-    <a href="https://github.com/Joe-Huber?tab=followers">
+    <a href="https://github.com/Joe-Huber?tab=followers" target="_blank" rel="noopener noreferrer">
       <img alt="Followers" src="https://img.shields.io/github/followers/Joe-Huber?style=for-the-badge&color=8A2BE2" />
     </a>
     <img alt="Stars" src="https://img.shields.io/github/stars/Joe-Huber?style=for-the-badge&color=8A2BE2" />
@@ -35,10 +35,10 @@
 
 <h2 id="connect">💜 Connect with me</h2>
 <p align="center">
-  <a href="https://www.linkedin.com/in/joe-huber-14a3a4316/" target="_blank">
+  <a href="https://www.linkedin.com/in/joe-huber-14a3a4316/" target="_blank" rel="noopener noreferrer">
     <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/linkedin/linkedin-original.svg" height="36" alt="LinkedIn" />
   </a>
-  <a href="https://github.com/Joe-Huber" target="_blank">
+  <a href="https://github.com/Joe-Huber" target="_blank" rel="noopener noreferrer">
     <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/github/github-original.svg" height="36" alt="GitHub" />
   </a>
   <a href="mailto:joseph.robert.huber@gmail.com">
@@ -55,15 +55,15 @@
       <strong>Languages</strong>
     </td>
     <td>
-      <a href="https://www.java.com/" target="_blank"><img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/java/java-original.svg" height="36" alt="Java" title="Java" /></a>
-      <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript" target="_blank"><img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/javascript/javascript-original.svg" height="36" alt="JavaScript" title="JavaScript" /></a>
-      <a href="https://www.typescriptlang.org/" target="_blank"><img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/typescript/typescript-plain.svg" height="36" alt="TypeScript" title="TypeScript" /></a>
-      <a href="https://www.python.org/" target="_blank"><img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/python/python-original.svg" height="36" alt="Python" title="Python" /></a>
-      <a href="https://www.mathworks.com/products/matlab.html" target="_blank"><img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/matlab/matlab-original.svg" height="36" alt="MATLAB" title="MATLAB" /></a>
-      <a href="https://developer.mozilla.org/en-US/docs/Web/Guide/HTML/HTML5" target="_blank"><img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/html5/html5-plain.svg" height="36" alt="HTML5" title="HTML5" /></a>
-      <a href="https://developer.mozilla.org/en-US/docs/Web/CSS" target="_blank"><img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/css3/css3-plain.svg" height="36" alt="CSS3" title="CSS3" /></a>
-      <a href="https://racket-lang.org/" target="_blank"><img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/racket/racket-original.svg" height="36" alt="Racket" title="Racket" /></a>
-      <a href="https://en.wikipedia.org/wiki/SQL" target="_blank"><img src="https://img.shields.io/badge/SQL-336791?style=for-the-badge&logo=postgresql&logoColor=white" height="26" alt="SQL" title="SQL" /></a>
+      <a href="https://www.java.com/" target="_blank" rel="noopener noreferrer"><img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/java/java-original.svg" height="36" alt="Java" title="Java" /></a>
+      <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript" target="_blank" rel="noopener noreferrer"><img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/javascript/javascript-original.svg" height="36" alt="JavaScript" title="JavaScript" /></a>
+      <a href="https://www.typescriptlang.org/" target="_blank" rel="noopener noreferrer"><img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/typescript/typescript-plain.svg" height="36" alt="TypeScript" title="TypeScript" /></a>
+      <a href="https://www.python.org/" target="_blank" rel="noopener noreferrer"><img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/python/python-original.svg" height="36" alt="Python" title="Python" /></a>
+      <a href="https://www.mathworks.com/products/matlab.html" target="_blank" rel="noopener noreferrer"><img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/matlab/matlab-original.svg" height="36" alt="MATLAB" title="MATLAB" /></a>
+      <a href="https://developer.mozilla.org/en-US/docs/Web/Guide/HTML/HTML5" target="_blank" rel="noopener noreferrer"><img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/html5/html5-plain.svg" height="36" alt="HTML5" title="HTML5" /></a>
+      <a href="https://developer.mozilla.org/en-US/docs/Web/CSS" target="_blank" rel="noopener noreferrer"><img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/css3/css3-plain.svg" height="36" alt="CSS3" title="CSS3" /></a>
+      <a href="https://racket-lang.org/" target="_blank" rel="noopener noreferrer"><img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/racket/racket-original.svg" height="36" alt="Racket" title="Racket" /></a>
+      <a href="https://en.wikipedia.org/wiki/SQL" target="_blank" rel="noopener noreferrer"><img src="https://img.shields.io/badge/SQL-336791?style=for-the-badge&logo=postgresql&logoColor=white" height="26" alt="SQL" title="SQL" /></a>
     </td>
   </tr>
   <tr>
@@ -71,12 +71,12 @@
       <strong>Frameworks & Libraries</strong>
     </td>
     <td>
-      <!-- <a href="https://spring.io/" target="_blank"><img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/spring/spring-original.svg" height="36" alt="Spring Framework" title="Spring Framework" /></a> -->
-      <!-- <a href="https://gradle.org/" target="_blank"><img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/gradle/gradle-original.svg" height="36" alt="Gradle" title="Gradle" /></a> -->
-      <a href="https://openjfx.io/" target="_blank"><img src="https://img.shields.io/badge/JavaFX-8A2BE2?style=for-the-badge" height="26" alt="JavaFX" title="JavaFX" /></a>
-      <a href="https://www.pygame.org/" target="_blank"><img src="https://img.shields.io/badge/Pygame-3776AB?style=for-the-badge&logo=python&logoColor=white" height="26" alt="Pygame" title="Pygame" /></a>
-      <a href="https://pandas.pydata.org/" target="_blank"><img src="https://img.shields.io/badge/Pandas-150458?style=for-the-badge&logo=pandas&logoColor=white" height="26" alt="Pandas" title="Pandas" /></a>
-      <a href="https://www.openapis.org/" target="_blank"><img src="https://img.shields.io/badge/OpenAPI-6BA539?style=for-the-badge&logo=openapiinitiative&logoColor=white" height="26" alt="OpenAPI" title="OpenAPI" /></a>
+      <!-- <a href="https://spring.io/" target="_blank" rel="noopener noreferrer"><img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/spring/spring-original.svg" height="36" alt="Spring Framework" title="Spring Framework" /></a> -->
+      <!-- <a href="https://gradle.org/" target="_blank" rel="noopener noreferrer"><img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/gradle/gradle-original.svg" height="36" alt="Gradle" title="Gradle" /></a> -->
+      <a href="https://openjfx.io/" target="_blank" rel="noopener noreferrer"><img src="https://img.shields.io/badge/JavaFX-8A2BE2?style=for-the-badge" height="26" alt="JavaFX" title="JavaFX" /></a>
+      <a href="https://www.pygame.org/" target="_blank" rel="noopener noreferrer"><img src="https://img.shields.io/badge/Pygame-3776AB?style=for-the-badge&logo=python&logoColor=white" height="26" alt="Pygame" title="Pygame" /></a>
+      <a href="https://pandas.pydata.org/" target="_blank" rel="noopener noreferrer"><img src="https://img.shields.io/badge/Pandas-150458?style=for-the-badge&logo=pandas&logoColor=white" height="26" alt="Pandas" title="Pandas" /></a>
+      <a href="https://www.openapis.org/" target="_blank" rel="noopener noreferrer"><img src="https://img.shields.io/badge/OpenAPI-6BA539?style=for-the-badge&logo=openapiinitiative&logoColor=white" height="26" alt="OpenAPI" title="OpenAPI" /></a>
     </td>
   </tr>
   <tr>
@@ -84,9 +84,9 @@
       <strong>Web Frontend & Runtime</strong>
     </td>
     <td>
-      <a href="https://react.dev/" target="_blank"><img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/react/react-original.svg" height="36" alt="React" title="React" /></a>
-      <a href="https://nextjs.org/" target="_blank"><img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/nextjs/nextjs-original.svg" height="36" alt="Next.js" title="Next.js" /></a>
-      <a href="https://nodejs.org/" target="_blank"><img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/nodejs/nodejs-original.svg" height="36" alt="Node.js" title="Node.js" /></a>
+      <a href="https://react.dev/" target="_blank" rel="noopener noreferrer"><img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/react/react-original.svg" height="36" alt="React" title="React" /></a>
+      <a href="https://nextjs.org/" target="_blank" rel="noopener noreferrer"><img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/nextjs/nextjs-original.svg" height="36" alt="Next.js" title="Next.js" /></a>
+      <a href="https://nodejs.org/" target="_blank" rel="noopener noreferrer"><img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/nodejs/nodejs-original.svg" height="36" alt="Node.js" title="Node.js" /></a>
     </td>
   </tr>
   <tr>
@@ -94,10 +94,10 @@
       <strong>Tools & Platforms</strong>
     </td>
     <td>
-      <a href="https://git-scm.com/" target="_blank"><img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/git/git-original.svg" height="36" alt="Git" title="Git" /></a>
-      <a href="https://github.com/" target="_blank"><img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/github/github-original.svg" height="36" alt="GitHub" title="GitHub" /></a>
-      <a href="https://developer.chrome.com/extensions/" target="_blank"><img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/chrome/chrome-plain.svg" height="36" alt="Chrome Extensions" title="Chrome Extensions" /></a>
-      <a href="https://www.jetbrains.com/" target="_blank"><img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/jetbrains/jetbrains-original.svg" height="36" alt="JetBrains" title="JetBrains" /></a>
+      <a href="https://git-scm.com/" target="_blank" rel="noopener noreferrer"><img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/git/git-original.svg" height="36" alt="Git" title="Git" /></a>
+      <a href="https://github.com/" target="_blank" rel="noopener noreferrer"><img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/github/github-original.svg" height="36" alt="GitHub" title="GitHub" /></a>
+      <a href="https://developer.chrome.com/extensions/" target="_blank" rel="noopener noreferrer"><img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/chrome/chrome-plain.svg" height="36" alt="Chrome Extensions" title="Chrome Extensions" /></a>
+      <a href="https://www.jetbrains.com/" target="_blank" rel="noopener noreferrer"><img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/jetbrains/jetbrains-original.svg" height="36" alt="JetBrains" title="JetBrains" /></a>
     </td>
   </tr>
   <tr>
@@ -105,8 +105,8 @@
       <strong>Web scraping</strong>
     </td>
     <td>
-      <a href="https://www.selenium.dev/" target="_blank"><img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/selenium/selenium-original.svg" height="36" alt="Selenium" title="Selenium" /></a>
-      <a href="https://playwright.dev/" target="_blank"><img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/playwright/playwright-original.svg" height="36" alt="Playwright" title="Playwright" /></a>
+      <a href="https://www.selenium.dev/" target="_blank" rel="noopener noreferrer"><img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/selenium/selenium-original.svg" height="36" alt="Selenium" title="Selenium" /></a>
+      <a href="https://playwright.dev/" target="_blank" rel="noopener noreferrer"><img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/playwright/playwright-original.svg" height="36" alt="Playwright" title="Playwright" /></a>
     </td>
   </tr>
   <tr>
@@ -114,9 +114,9 @@
       <strong>Cloud</strong>
     </td>
     <td>
-      <a href="https://www.cloudflare.com/" target="_blank"><img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/cloudflare/cloudflare-original.svg" height="36" alt="Cloudflare" title="Cloudflare" /></a>
-      <a href="https://aws.amazon.com/s3/" target="_blank"><img src="https://img.shields.io/badge/AWS%20S3-232F3E?style=for-the-badge&logo=amazonaws&logoColor=white" height="26" alt="AWS S3" title="AWS S3" /></a>
-      <a href="https://www.snowflake.com/" target="_blank"><img src="https://img.shields.io/badge/Snowflake-29B5E8?style=for-the-badge&logo=snowflake&logoColor=white" height="26" alt="Snowflake" title="Snowflake" /></a>
+      <a href="https://www.cloudflare.com/" target="_blank" rel="noopener noreferrer"><img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/cloudflare/cloudflare-original.svg" height="36" alt="Cloudflare" title="Cloudflare" /></a>
+      <a href="https://aws.amazon.com/s3/" target="_blank" rel="noopener noreferrer"><img src="https://img.shields.io/badge/AWS%20S3-232F3E?style=for-the-badge&logo=amazonaws&logoColor=white" height="26" alt="AWS S3" title="AWS S3" /></a>
+      <a href="https://www.snowflake.com/" target="_blank" rel="noopener noreferrer"><img src="https://img.shields.io/badge/Snowflake-29B5E8?style=for-the-badge&logo=snowflake&logoColor=white" height="26" alt="Snowflake" title="Snowflake" /></a>
       <a href="https://supabase.com/" target="_blank" rel="noopener noreferrer"><img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/supabase/supabase-original.svg" height="36" alt="Supabase" title="Supabase" /></a>
     </td>
   </tr>
@@ -125,11 +125,11 @@
       <strong>AI & Assistants</strong>
     </td>
     <td>
-      <a href="https://www.anthropic.com/" target="_blank"><img src="https://img.shields.io/badge/Claude-111?style=for-the-badge&logo=anthropic&logoColor=white" height="26" alt="Claude" title="Claude" /></a>
-      <a href="https://gemini.google.com/" target="_blank"><img src="https://img.shields.io/badge/Gemini-0B57D0?style=for-the-badge&logo=googlegemini&logoColor=white" height="26" alt="Gemini" title="Gemini" /></a>
-      <a href="https://github.com/features/copilot" target="_blank"><img src="https://img.shields.io/badge/GitHub%20Copilot-181717?style=for-the-badge&logo=githubcopilot&logoColor=white" height="26" alt="GitHub Copilot" title="GitHub Copilot" /></a>
-      <a href="https://cursor.sh/" target="_blank"><img src="https://img.shields.io/badge/Cursor-1A1F36?style=for-the-badge&logoColor=white" height="26" alt="Cursor" title="Cursor" /></a>
-      <a href="https://qodo.ai/" target="_blank"><img src="https://img.shields.io/badge/Qodo-8A2BE2?style=for-the-badge" height="26" alt="Qodo" title="Qodo" /></a>
+      <a href="https://www.anthropic.com/" target="_blank" rel="noopener noreferrer"><img src="https://img.shields.io/badge/Claude-111?style=for-the-badge&logo=anthropic&logoColor=white" height="26" alt="Claude" title="Claude" /></a>
+      <a href="https://gemini.google.com/" target="_blank" rel="noopener noreferrer"><img src="https://img.shields.io/badge/Gemini-0B57D0?style=for-the-badge&logo=googlegemini&logoColor=white" height="26" alt="Gemini" title="Gemini" /></a>
+      <a href="https://github.com/features/copilot" target="_blank" rel="noopener noreferrer"><img src="https://img.shields.io/badge/GitHub%20Copilot-181717?style=for-the-badge&logo=githubcopilot&logoColor=white" height="26" alt="GitHub Copilot" title="GitHub Copilot" /></a>
+      <a href="https://cursor.sh/" target="_blank" rel="noopener noreferrer"><img src="https://img.shields.io/badge/Cursor-1A1F36?style=for-the-badge&logoColor=white" height="26" alt="Cursor" title="Cursor" /></a>
+      <a href="https://qodo.ai/" target="_blank" rel="noopener noreferrer"><img src="https://img.shields.io/badge/Qodo-8A2BE2?style=for-the-badge" height="26" alt="Qodo" title="Qodo" /></a>
     </td>
   </tr>
 </table>
@@ -140,12 +140,12 @@
 <table>
   <tr>
     <td width="140" align="center" valign="middle" id="experience">
-      <a href="https://system1.com/" target="_blank">
+      <a href="https://system1.com/" target="_blank" rel="noopener noreferrer">
         <img src="docs/system1-logo.webp" alt="System1 logo" width="120" loading="lazy" />
       </a>
     </td>
     <td>
-      <h3><a href="https://system1.com/" target="_blank">System1</a></h3>
+      <h3><a href="https://system1.com/" target="_blank" rel="noopener noreferrer">System1</a></h3>
       <p>
         System1 operates an industry-leading responsive acquisition marketing platform (RAMP) powered by AI and machine learning.
       </p>
@@ -156,12 +156,12 @@
   </tr>
   <tr>
     <td width="140" align="center" valign="middle">
-      <a href="https://www.pvnet.com/" target="_blank">
+      <a href="https://www.pvnet.com/" target="_blank" rel="noopener noreferrer">
         <img src="docs/pvnet-logo.jpg" alt="PVNet Technology Education Center logo" width="120" loading="lazy" />
       </a>
     </td>
     <td>
-      <h3><a href="https://www.pvnet.com/" target="_blank">PVNet Technology Education Center</a></h3>
+      <h3><a href="https://www.pvnet.com/" target="_blank" rel="noopener noreferrer">PVNet Technology Education Center</a></h3>
       <p>
         PVNet is a non-profit community technology organization offering STEM education for ages 10–104, from novice to professional.
       </p>
@@ -178,12 +178,12 @@
 <table>
   <tr>
     <td width="140" align="center" valign="middle">
-      <a href="https://www.northwestern.edu/" target="_blank">
+      <a href="https://www.northwestern.edu/" target="_blank" rel="noopener noreferrer">
         <img src="docs/northwestern-logo.svg" alt="Northwestern University logo" width="120" loading="lazy" />
       </a>
     </td>
     <td>
-      <h3><a href="https://www.northwestern.edu/" target="_blank">Northwestern University</a></h3>
+      <h3><a href="https://www.northwestern.edu/" target="_blank" rel="noopener noreferrer">Northwestern University</a></h3>
       <p>
         McCormick School of Engineering
       </p>
@@ -195,12 +195,12 @@
   </tr>
   <tr>
     <td width="140" align="center" valign="middle">
-      <a href="https://www.chadwickschool.org/" target="_blank">
+      <a href="https://www.chadwickschool.org/" target="_blank" rel="noopener noreferrer">
         <img src="docs/chadwick-logo.jpeg" alt="Chadwick School logo" width="120" loading="lazy" />
       </a>
     </td>
     <td>
-      <h3><a href="https://www.chadwickschool.org/" target="_blank">Chadwick School</a></h3>
+      <h3><a href="https://www.chadwickschool.org/" target="_blank" rel="noopener noreferrer">Chadwick School</a></h3>
       <ul>
         <li><strong>Graduation Year:</strong> 2025</li>
       </ul>
@@ -214,19 +214,19 @@
 <table>
   <tr>
     <td width="50%" valign="top" id="projects">
-      <a href="https://github.com/Joe-Huber/CopyPastePlus" target="_blank">
+      <a href="https://github.com/Joe-Huber/CopyPastePlus" target="_blank" rel="noopener noreferrer">
         <img src="docs/copypasteplus-banner.png" alt="CopyPaste+ banner" width="100%" loading="lazy" />
       </a>
-      <h3><a href="https://github.com/Joe-Huber/CopyPastePlus" target="_blank">CopyPaste+</a></h3>
+      <h3><a href="https://github.com/Joe-Huber/CopyPastePlus" target="_blank" rel="noopener noreferrer">CopyPaste+</a></h3>
       <p>
         Expand copy/paste in Chrome with a history, favorites, and usage counts — all from the toolbar popup.
       </p>
     </td>
     <td width="50%" valign="top">
-      <a href="https://github.com/moonish1211/Cosmic-Crashout-Public" target="_blank">
+      <a href="https://github.com/moonish1211/Cosmic-Crashout-Public" target="_blank" rel="noopener noreferrer">
         <img src="docs/cosmic-crashout-logo.png" alt="Cosmic Crashout logo" width="100%" loading="lazy" />
       </a>
-      <h3><a href="https://github.com/moonish1211/Cosmic-Crashout-Public" target="_blank">Cosmic Crashout</a></h3>
+      <h3><a href="https://github.com/moonish1211/Cosmic-Crashout-Public" target="_blank" rel="noopener noreferrer">Cosmic Crashout</a></h3>
       <p>
         An accessible game designed for quadriplegic players using the OpenBCI EEG headset. Built with PVNet Advanced Technology Center.
       </p>
@@ -234,30 +234,30 @@
   </tr>
   <tr>
     <td width="50%" valign="top">
-      <a href="https://github.com/Joe-Huber/Text-Editor" target="_blank">
+      <a href="https://github.com/Joe-Huber/Text-Editor" target="_blank" rel="noopener noreferrer">
         <img src="docs/text-editor-logo.png" alt="Text Editor logo" width="50%" loading="lazy" style="display:block;margin:0 auto;" />
       </a>
-      <h3><a href="https://github.com/Joe-Huber/Text-Editor" target="_blank">Text Editor</a></h3>
+      <h3><a href="https://github.com/Joe-Huber/Text-Editor" target="_blank" rel="noopener noreferrer">Text Editor</a></h3>
       <p>
         A JavaFX learning-focused editor with a custom Document → Paragraph → Word → Character model and a clear render pipeline.
       </p>
     </td>
     <td width="50%" valign="middle" align="center">
-      <p><a href="https://github.com/Joe-Huber?tab=repositories" target="_blank">Explore more repositories →</a></p>
+      <p><a href="https://github.com/Joe-Huber?tab=repositories" target="_blank" rel="noopener noreferrer">Explore more repositories →</a></p>
     </td>
   </tr>
 </table>
 
 <!-- Pinned repo cards -->
 <div align="center">
-  <a href="https://github.com/Joe-Huber/CopyPastePlus" target="_blank">
+  <a href="https://github.com/Joe-Huber/CopyPastePlus" target="_blank" rel="noopener noreferrer">
     <picture>
       <source media="(prefers-color-scheme: dark)" srcset="https://github-readme-stats.vercel.app/api/pin/?username=Joe-Huber&repo=CopyPastePlus&theme=shades-of-purple" />
       <source media="(prefers-color-scheme: light)" srcset="https://github-readme-stats.vercel.app/api/pin/?username=Joe-Huber&repo=CopyPastePlus&theme=buefy" />
       <img alt="CopyPaste+ pin" src="https://github-readme-stats.vercel.app/api/pin/?username=Joe-Huber&repo=CopyPastePlus&theme=buefy" />
     </picture>
   </a>
-  <a href="https://github.com/Joe-Huber/Text-Editor" target="_blank">
+  <a href="https://github.com/Joe-Huber/Text-Editor" target="_blank" rel="noopener noreferrer">
     <picture>
       <source media="(prefers-color-scheme: dark)" srcset="https://github-readme-stats.vercel.app/api/pin/?username=Joe-Huber&repo=Text-Editor&theme=shades-of-purple" />
       <source media="(prefers-color-scheme: light)" srcset="https://github-readme-stats.vercel.app/api/pin/?username=Joe-Huber&repo=Text-Editor&theme=buefy" />
@@ -281,7 +281,7 @@
     <img alt="Top Languages" src="https://github-readme-stats.vercel.app/api/top-langs/?username=joe-huber&layout=compact&theme=buefy" height="160" loading="lazy" />
   </picture>
   <br/>
-  <a href="https://git.io/streak-stats" target="_blank">
+  <a href="https://git.io/streak-stats" target="_blank" rel="noopener noreferrer">
     <picture>
       <source media="(prefers-color-scheme: dark)" srcset="https://streak-stats.demolab.com/?user=Joe-Huber&theme=shades-of-purple" />
       <source media="(prefers-color-scheme: light)" srcset="https://streak-stats.demolab.com/?user=Joe-Huber&theme=buefy" />


### PR DESCRIPTION
**NOTE**

target="_blank" rel="noopener noreferrer" DOES NOT WORK
This is because github doesn't allow it :( https://stackoverflow.com/questions/41915571/open-link-in-new-tab-with-github-markdown-using-target-blank
i left it in just for funsies, in case github ever changes that